### PR TITLE
made the methods in LogUtil display the id of the current thread

### DIFF
--- a/src/main/java/com/spikes2212/prometheus_server/util/LogUtil.java
+++ b/src/main/java/com/spikes2212/prometheus_server/util/LogUtil.java
@@ -19,12 +19,14 @@ public class LogUtil {
 
     public static void error(String title, String data) {
         if (enabled) {
+            System.out.println(ANSI_COLORS.ANSI_RED + "Error Log from thread " + Thread.currentThread().getId());
             System.out.println(ANSI_COLORS.ANSI_RED + "Error - " + title + " : " + data + ANSI_COLORS.ANSI_RESET);
         }
     }
 
     public static void data(String title, String data) {
         if (enabled) {
+            System.out.println(ANSI_COLORS.ANSI_GREEN + "Data Log from thread " + Thread.currentThread().getId());
             System.out.println(ANSI_COLORS.ANSI_GREEN + "Data - " + title + " : " + data + ANSI_COLORS.ANSI_RESET);
         }
     }


### PR DESCRIPTION
made the data and error methods display the id of the current thread, a feature that may be useful when debugging the project when multiple threads are used for networking.