### PR TITLE
Message process method

### DIFF
--- a/src/main/java/com/spikes2212/prometheus_server/network/ListeningRunnable.java
+++ b/src/main/java/com/spikes2212/prometheus_server/network/ListeningRunnable.java
@@ -35,7 +35,13 @@ public class ListeningRunnable implements Runnable {
         }
     }
     private void processMessageMap(Map<String, String> messageMap) {
+        Message msg = null;
+        // processing message from messageMap
 
+        if (msg != null) {
+            msg.fromMap(messageMap);
+            msg.process(usersCollection, groupsCollection, connection);
+        }
     }
 
 }

--- a/src/main/java/com/spikes2212/prometheus_server/network/message/Message.java
+++ b/src/main/java/com/spikes2212/prometheus_server/network/message/Message.java
@@ -1,9 +1,17 @@
 package com.spikes2212.prometheus_server.network.message;
 
+import com.spikes2212.prometheus_server.database.TypedCollection;
+import com.spikes2212.prometheus_server.network.Connection;
+import com.spikes2212.prometheus_server.network.data.Group;
+import com.spikes2212.prometheus_server.network.data.User;
+
 import java.util.Map;
 
 public abstract class Message {
     public String id;
 
     public abstract void fromMap(Map<String, String> map);
+
+    public abstract void process(TypedCollection<User> users,
+                                 TypedCollection<Group> group, Connection connection);
 }


### PR DESCRIPTION
added abstract process method to Message, and basic implementation to ListeningRunnable.processMessageMap that initializes Message object as null. creates new message depends on the id value received from messageMap.get("id"). and process it using Message.process()